### PR TITLE
Migrate custom data references to DataSource repo

### DIFF
--- a/CachedCBOEDataAlgorithm.cs
+++ b/CachedCBOEDataAlgorithm.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.DataLibrary.Tests
+{
+    public class CachedCBOEDataAlgorithm : QCAlgorithm
+    {
+        private Symbol _cboeVix;
+
+        public override void Initialize()
+        {
+            SetStartDate(2003, 1, 1);
+            SetEndDate(2019, 10, 11);
+            SetCash(100000);
+
+            // QuantConnect caches a small subset of alternative data for easy consumption for the community.
+            // You can use this in your algorithm as demonstrated below:
+            _cboeVix = AddData<CBOE>("VIX", Resolution.Daily).Symbol;
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (data.ContainsKey(_cboeVix))
+            {
+                var vix = data.Get<CBOE>(_cboeVix);
+                Log($"VIX: {vix}");
+            }
+        }
+    }
+}

--- a/CachedCBOEDataAlgorithm.py
+++ b/CachedCBOEDataAlgorithm.py
@@ -1,0 +1,31 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from QuantConnect.DataSource import *
+
+class CachedCBOEDataAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2003, 1, 1)
+        self.SetEndDate(2019, 10, 11)
+        self.SetCash(100000)
+
+        # QuantConnect caches a small subset of alternative data for easy consumption for the community.
+        # You can use this in your algorithm as demonstrated below:
+        self.cboeVix = self.AddData(CBOE, "VIX", Resolution.Daily).Symbol
+
+    def OnData(self, data):
+        if data.ContainsKey(self.cboeVix):
+            vix = data.Get(CBOE, self.cboeVix)
+            self.Log(f"VIX: {vix}")

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="QuantConnect.Common" Version="2.5.11800" />
+    <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
     <PackageReference Include="protobuf-net" Version="3.0.29" />
-    <PackageReference Include="protobuf-net.Core" Version="3.0.29" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
@@ -24,6 +23,8 @@
     <None Remove="process.sample.ipynb" />
     <None Remove="process.sample.py" />
     <None Remove="process.sample.sh" />
+    <Compile Remove="CachedCBOEDataAlgorithm.cs" />
+    <None Remove="CachedCBOEDataAlgorithm.py" />
   </ItemGroup>
 
 </Project>

--- a/tests/CBOETests.cs
+++ b/tests/CBOETests.cs
@@ -33,11 +33,11 @@ namespace QuantConnect.DataLibrary.Tests
         public void EndTimeShiftedOneDayForward()
         {
             var date = new DateTime(2020, 5, 21);
-            var cboe = new QuantConnect.Data.Custom.CBOE.CBOE();
+            var cboe = new CBOE();
             var cboeData = "2020-05-21,1,1,1,1";
-            var symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(QuantConnect.Data.Custom.CBOE.CBOE), "VIX", QuantConnect.Market.USA), "VIX");
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(CBOE), "VIX", QuantConnect.Market.USA), "VIX");
             var actual = cboe.Reader(new SubscriptionDataConfig(
-                typeof(QuantConnect.Data.Custom.CBOE.CBOE),
+                typeof(CBOE),
                 symbol,
                 Resolution.Daily,
                 QuantConnect.TimeZones.Utc,

--- a/tests/CBOETests.cs
+++ b/tests/CBOETests.cs
@@ -30,6 +30,28 @@ namespace QuantConnect.DataLibrary.Tests
     public class CBOETests
     {
         [Test]
+        public void EndTimeShiftedOneDayForward()
+        {
+            var date = new DateTime(2020, 5, 21);
+            var cboe = new QuantConnect.Data.Custom.CBOE.CBOE();
+            var cboeData = "2020-05-21,1,1,1,1";
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(QuantConnect.Data.Custom.CBOE.CBOE), "VIX", QuantConnect.Market.USA), "VIX");
+            var actual = cboe.Reader(new SubscriptionDataConfig(
+                typeof(QuantConnect.Data.Custom.CBOE.CBOE),
+                symbol,
+                Resolution.Daily,
+                QuantConnect.TimeZones.Utc,
+                QuantConnect.TimeZones.Utc,
+                false,
+                false,
+                false,
+                true), cboeData, date, false);
+
+            Assert.AreEqual(date, actual.Time);
+            Assert.AreEqual(date.AddDays(1), actual.EndTime);
+        }
+
+        [Test]
         public void JsonRoundTrip()
         {
             var expected = CreateNewInstance();

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Demonstration.cs" Link="Demonstration.cs" />
+    <Compile Include="..\CachedCBOEDataAlgorithm.cs" Link="CachedCBOEDataAlgorithm.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.0.29" />
-    <PackageReference Include="protobuf-net.Core" Version="3.0.29" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.4" />
-    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.11800" />
+    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />


### PR DESCRIPTION
All relevant data/tests from Lean have been copied over to this repo as part of the custom data removal PRs