### PR TITLE
Adds VIX1Y - 1-year Expiry VIX

### DIFF
--- a/process.sh
+++ b/process.sh
@@ -28,6 +28,7 @@ try_cboe_download TYVIX tyvix
 try_cboe_download VIX3M vix3m
 try_cboe_download VIX6M vix6m
 try_cboe_download VIX9D vix9d
+try_cboe_download VIX1Y vix1y
 
 echo "Uploading CBOE data files to cache bucket"
 aws s3 sync $destination_folder/ s3://cache.quantconnect.com/


### PR DESCRIPTION
We can confirm it has the right format here:
https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX1Y_History.csv

How was tested:
- Ran the script locally