### PR TITLE
Supports Single Column Assets

### DIFF
--- a/CBOE.cs
+++ b/CBOE.cs
@@ -80,15 +80,13 @@ namespace QuantConnect.DataSource
                 .Select(x => x.Trim())
                 .ToList();
 
-            decimal open;
-            decimal high;
-            decimal low;
-            decimal close;
+            // Some data data has only one column, so all values will be the same
+            var indices = csv.Count == 2 ? new[] { 1, 1, 1, 1 } : new[] { 1, 2, 3, 4 };
 
-            QuantConnect.Parse.TryParse(csv[1], NumberStyles.Any, out open);
-            QuantConnect.Parse.TryParse(csv[2], NumberStyles.Any, out high);
-            QuantConnect.Parse.TryParse(csv[3], NumberStyles.Any, out low);
-            QuantConnect.Parse.TryParse(csv[4], NumberStyles.Any, out close);
+            QuantConnect.Parse.TryParse(csv[indices[0]], NumberStyles.Any, out decimal open);
+            QuantConnect.Parse.TryParse(csv[indices[1]], NumberStyles.Any, out decimal high);
+            QuantConnect.Parse.TryParse(csv[indices[2]], NumberStyles.Any, out decimal low);
+            QuantConnect.Parse.TryParse(csv[indices[3]], NumberStyles.Any, out decimal close);
 
             return new CBOE
             {

--- a/tests/CBOETests.cs
+++ b/tests/CBOETests.cs
@@ -52,6 +52,33 @@ namespace QuantConnect.DataLibrary.Tests
         }
 
         [Test]
+        public void SingleColumnData()
+        {
+            const decimal expected = 123m;
+            var date = new DateTime(2020, 5, 21);
+            var cboe = new CBOE();
+            var cboeData = $"2020-05-21,{expected}";
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(CBOE), "VIX", QuantConnect.Market.USA), "VIX");
+            var actual = cboe.Reader(new SubscriptionDataConfig(
+                typeof(CBOE),
+                symbol,
+                Resolution.Daily,
+                QuantConnect.TimeZones.Utc,
+                QuantConnect.TimeZones.Utc,
+                false,
+                false,
+                false,
+                true), cboeData, date, false) as CBOE;
+
+            Assert.AreEqual(date, actual.Time);
+            Assert.AreEqual(date.AddDays(1), actual.EndTime);
+            Assert.AreEqual(expected, actual.Open);
+            Assert.AreEqual(expected, actual.High);
+            Assert.AreEqual(expected, actual.Low);
+            Assert.AreEqual(expected, actual.Close);
+        }
+
+        [Test]
         public void JsonRoundTrip()
         {
             var expected = CreateNewInstance();


### PR DESCRIPTION
The assets VVIX, VXTLT, OVX and GVZ only has the closing price.